### PR TITLE
fixed defect: git searchPath {application}  does not work

### DIFF
--- a/scca-plugin-git/src/main/java/com/didispace/scca/plugin/git/GitPropertyController.java
+++ b/scca-plugin-git/src/main/java/com/didispace/scca/plugin/git/GitPropertyController.java
@@ -198,10 +198,12 @@ public class GitPropertyController {
             // 生成本地拉取配置用来修改使用的唯一目录名
             this.dir = UUID.randomUUID().toString();
 
+            String searchPaths = gitProperties.getSearchPaths().replaceFirst("\\{application\\}", application);
+
             for (String pattern : gitPlusProperties.getFilePattern().split(",")) {
                 String propertiesFile = pattern.replaceFirst("\\{application\\}", application).replaceFirst("\\{profile\\}", profile);
                 this.propertiesFiles.add(propertiesFile);
-                this.path.add(this.dir + gitProperties.getSearchPaths() + "/" + propertiesFile);
+                this.path.add(this.dir + searchPaths + "/" + propertiesFile);
             }
             log.info("properties file : " + this.path);
         }


### PR DESCRIPTION
scca config server added property:spring.cloud.config.server.git.search-paths=/{application}, but it doesn't work, I had fixed it